### PR TITLE
修正EXACT的实现

### DIFF
--- a/java/toolgood.algorithm/src/main/java/toolgood/algorithm/internals/MathVisitor.java
+++ b/java/toolgood.algorithm/src/main/java/toolgood/algorithm/internals/MathVisitor.java
@@ -1822,7 +1822,7 @@ public class MathVisitor extends AbstractParseTreeVisitor<Operand> implements ma
         final List<Operand> args = new ArrayList<Operand>();
         int index = 1;
         for (final ExprContext item : context.expr()) {
-            final Operand aa = item.accept(this).ToNumber("Function EXACT parameter " + (index++) + " is error!");
+            final Operand aa = item.accept(this).ToText("Function EXACT parameter " + (index++) + " is error!");
             if (aa.IsError()) {
                 return aa;
             }
@@ -1832,7 +1832,7 @@ public class MathVisitor extends AbstractParseTreeVisitor<Operand> implements ma
         final Operand firstValue = args.get(0);
         final Operand secondValue = args.get(1);
 
-        return Operand.Create(firstValue.TextValue() == secondValue.TextValue());
+        return Operand.Create(firstValue.TextValue().equals(secondValue.TextValue()));
     }
 
     public Operand visitFIND_fun(final FIND_funContext context) {

--- a/java/toolgood.algorithm/src/test/java/toolgood/algorithm/Tests/AlgorithmEngineTest_string.java
+++ b/java/toolgood.algorithm/src/test/java/toolgood/algorithm/Tests/AlgorithmEngineTest_string.java
@@ -62,6 +62,10 @@ public class AlgorithmEngineTest_string {
             assertEquals(t, false);
             t = engine.TryEvaluate("EXACT('tt','tt')", true);
             assertEquals(t, true);
+            t = engine.TryEvaluate("EXACT('tt','33')", true);
+            assertEquals(t, false);
+            t = engine.TryEvaluate("EXACT('tt','tt')", false);
+            assertEquals(t, true);
         }
         @Test
         public void FIND_test()


### PR DESCRIPTION
EXACT的实现不正确，单元测试用例也掩盖了错误。

https://support.microsoft.com/en-us/office/exact-function-d3087698-fc15-4a15-9631-12575cf29926